### PR TITLE
runner type+uniqe iam resource names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,11 +49,16 @@ module "vpc_endpoints" {
   }
 }
 
+resource "random_id" "unique_prefix" {
+  byte_length = 4
+}
+
 module "runner-instance" {
   source  = "cattle-ops/gitlab-runner/aws"
   version = "7.5.0"
 
-  environment = var.environment
+  environment       = var.environment
+  iam_object_prefix = random_id.unique_prefix.hex
 
   vpc_id    = module.vpc.vpc_id
   subnet_id = element(module.vpc.private_subnets, 0)
@@ -112,7 +117,7 @@ module "runner-instance" {
     name                        = "pe-workers"
     name_prefix                 = "${var.runner_name}"
     ssm_access                  = true
-    type                        = "t3.medium"
+    type                        = var.runner_instance_type
   }
 
   runner_cloudwatch = {

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,9 @@ variable "role_profile_name" {
   type        = string
   default     = "dev-gitlab-runners"
 }
+
+variable "runner_instance_type" {
+  description = "Runner Instance Type"
+  type        = string
+  default     = "t3.medium"
+}


### PR DESCRIPTION
1. ARM based runner is required for the github.com/bootc-org for building multi-arch container images. Gitlab.com doesn't have arm based runners. Therefor, a self hosted runner arm based is required.
This module will be used for spinning both amd and arm based runners so it would make sense to varbalize the runner instance type. This key controls the runner arch.
The control over the runner instance type and ami would be handled in the infrastructure-live repo. 

2. I was trying to spin a new environment in the same AWS account. Was hitting a resource already exist error on a IAM resource.  This change will make the IAM resource names unique.