### PR TITLE
Do not override role_profile_name value assigned by the module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -145,8 +145,5 @@ module "runner-instance" {
 
   runner_gitlab_token_secure_parameter_store = "runner-token"
   runner_sentry_secure_parameter_store_name  = "sentry-dsn"
-  runner_role = {
-    role_profile_name = var.role_profile_name
-  }
-  runner_terminate_ec2_lifecycle_hook_name = "terminate-instances"
+  runner_terminate_ec2_lifecycle_hook_name   = "terminate-instances"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -86,12 +86,6 @@ variable "runners_root_size" {
   default     = 8
 }
 
-variable "role_profile_name" {
-  description = "IAM Role Profile Name"
-  type        = string
-  default     = "dev-gitlab-runners"
-}
-
 variable "runner_instance_type" {
   description = "Runner Instance Type"
   type        = string


### PR DESCRIPTION
Using this module for multiple environment in the same AWS account causing the following errors:
```
│ Error: creating IAM Instance Profile (dev-gitlab-runners): operation error IAM: CreateInstanceProfile, https response error StatusCode: 409, RequestID: a09e96a7-1f8c-4d94-b84d-4bd7f71205cf, EntityAlreadyExists: Instance Profile dev-gitlab-runners already exists.
│ 
│   with module.runner-instance.aws_iam_instance_profile.instance[0],
│   on .terraform/modules/runner-instance/main.tf line 400, in resource "aws_iam_instance_profile" "instance":
│  400: resource "aws_iam_instance_profile" "instance" {
│ 
╵
╷
│ Error: creating IAM Role (dev-gitlab-runners): operation error IAM: CreateRole, https response error StatusCode: 409, RequestID: 7caf118b-5835-4ee6-813a-160d5d4d3d88, EntityAlreadyExists: Role with name dev-gitlab-runners already exists.
│ 
│   with module.runner-instance.aws_iam_role.instance[0],
│   on .terraform/modules/runner-instance/main.tf line 409, in resource "aws_iam_role" "instance":
│  409: resource "aws_iam_role" "instance" {
│ 
╵
```
Removing the variable override such that the upstream module would set it value uniquely