### PR TITLE
enable max job concurrency downstream

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,10 @@ module "runner-instance" {
   runner_worker_docker_machine_ami_filter = var.runner_worker_docker_machine_ami_filter
   runner_worker_docker_machine_ami_owners = var.runner_worker_docker_machine_ami_owners
 
+  runner_manager = {
+    maxiumum_concurrent_jobs = var.runner_manager_maximum_concurrent_jobs
+  }
+
   runner_gitlab_registration_config = {
     type              = "group"
     group_id          = var.gitlab_group_id

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,12 @@ variable "runner_worker_docker_machine_instance_types" {
   default     = ["t3.medium"]
 }
 
+variable "runner_manager_maximum_concurrent_jobs" {
+  description = "The number of maximum concurrent jobs allowed for an environment"
+  type        = number
+  default     = 10
+}
+
 variable "runner_instance_type" {
   description = "Runner Instance Type"
   type        = string


### PR DESCRIPTION
cc @lmilbaum 
This should give us the variable. Once we have this ill cut a new release and then update my `infrastrucutre-live` mr use the variable we define here instead of the obeject.